### PR TITLE
fix: use Klass() instead of hardcoded Sym() in _symCuts

### DIFF
--- a/ezr/ezr.py
+++ b/ezr/ezr.py
@@ -309,8 +309,7 @@ def _symCuts(at, xys, Y, Klass) -> (float, list[Op]):
     unique_vals = set(x for x, _ in xys)
     spread, cuts = big, []
     for val in unique_vals:
-        #  left, right = Klass(), Klass()
-        left, right = Sym(), Sym()
+        left, right = Klass(), Klass()
 
         [add(left if x == val else right, y) for x, y in xys]
         if left.n >= the.leaf and right.n >= the.leaf:


### PR DESCRIPTION
Fixes #45

## Problem
`_symCuts` hardcodes `Sym()` accumulators instead of using the `Klass` parameter. When Y values are continuous floats (e.g., distance-to-heaven scores from `disty()`), `Sym` computes Shannon entropy treating each float as a distinct category, producing near-identical log(n) scores for all splits. The best symbolic split is chosen essentially at random.

## Fix
```python
# Before (line 313):
left, right = Sym(), Sym()

# After:
left, right = Klass(), Klass()
```

When `Klass=Num` (the default from `Tree()`), the accumulators use standard deviation as the spread measure, correctly evaluating how well a symbolic split separates continuous Y values. This matches `_numCuts` which already correctly uses `Klass()`. The commented-out original on line 312 confirms this was the intended behavior.