### PR TITLE
Fix like() returning positive value instead of negative log-prob when sd=0

### DIFF
--- a/ezr/ezr.py
+++ b/ezr/ezr.py
@@ -214,7 +214,7 @@ def like(i:o, v:Any, prior=0) -> float :
     return math.log(max(tmp, 1e-32))
   else:
     ## Next Line added to resolve cases where i.sd == 0
-    if i.sd == 0: return 0 if v == i.mu else 1E-32
+    if i.sd == 0: return 0 if v == i.mu else math.log(1E-32)
     
     var = i.sd * i.sd + 1E-32
     log_nom = -1 * (v - i.mu) ** 2 / (2 * var)


### PR DESCRIPTION
## Summary
- When a Num column has `sd=0` and `v != mu`, `like()` was returning `1E-32` (positive), but all other code paths return negative log-probabilities
- Changed to `math.log(1E-32)` (~-73.7) which correctly encodes "extremely unlikely"

## Test plan
- [ ] Verify Bayesian acquisition functions (`xploit`, `xplor`, `bore`, `adapt`) produce correct rankings on datasets where early columns have zero variance
- [ ] Run `python3 -B ezrtest.py --likely` to confirm no regression

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)