### PR TITLE
Fix likes() to pass prior to like() for proper Laplace smoothing

### DIFF
--- a/ezr/ezr.py
+++ b/ezr/ezr.py
@@ -225,7 +225,7 @@ def likes(data:Data, row:Row, nall=100, nh=2) -> float:
   "How much does this DATA like row?"
   prior = data.n / (nall + 1e-32)
   log_prior = math.log(max(prior, 1e-32))
-  tmp = [like(c, row[c.at]) for c in data.cols.x if row[c.at] != "?"]
+  tmp = [like(c, row[c.at], prior) for c in data.cols.x if row[c.at] != "?"]
   return log_prior + sum(tmp)    
 
 # ## Active Learning --------------------------------------------------


### PR DESCRIPTION
## Summary
- `likes()` computed a `prior` value but never forwarded it to `like()`, so `prior` always defaulted to 0
- Laplace smoothing `(the.m * prior)` was effectively disabled for Sym columns
- Unseen symbolic values got an extremely harsh log-penalty (~-73.5) that dominated the likelihood sum

## Test plan
- [ ] Run `python3 -B ezrtest.py --likes` to verify likelihoods are in expected range
- [ ] Run `python3 -B ezrtest.py --likely` with Bayesian acquisition functions to confirm improved behavior on datasets with sparse symbolic features

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)