### PR TITLE
Fix distFastermap to slice sorted projection instead of unsorted raw

### DIFF
--- a/ezr/ezr.py
+++ b/ezr/ezr.py
@@ -200,7 +200,7 @@ def distFastermap(data,rows=None, sway2=True):
     add(out, east)
     add(out, west)
     n   = len(rest)//2
-    raw = raw[:n] if Y(east) < Y(west) else raw[n:]
+    raw = rest[:n] if Y(east) < Y(west) else rest[n:]
     if sway2 and len(raw) < 2:
       raw = shuffle([r for r in rows if r not in out.rows])
   return sorted(out.rows, key=Y)


### PR DESCRIPTION
## Summary
- `distFastmap()` returns a new sorted list, but the halving step sliced the original unsorted `raw`
- This made the projection-based pruning equivalent to random sampling
- Now slices `rest` (the sorted projection result) so the half closer to the better pole is kept

## Test plan
- [ ] Run `python3 -B ezrtest.py --fmap` to compare sway1/sway2 performance — sway2 should now outperform random
- [ ] Run `make ~/tmp/dist.log` to verify kpp/sway1/sway2 experiments

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)