### PR TITLE
Fix xplore typo, eg__tree crash, and epsilon guard placement

### DIFF
--- a/ezr/ezr.py
+++ b/ezr/ezr.py
@@ -268,7 +268,7 @@ def likelier(_, best:Data, rest:Data, x:Data) -> Row:
   def _fn(row):
     b,r = e**likes(best,row,nall,2), e**likes(rest,row,nall,2)
     if the.acq=="bore": return b*b/(r+1e-32)
-    return (b + r*q) / abs(b*q - r + 1e-32)
+    return (b + r*q) / (abs(b*q - r) + 1e-32)
   first, *lst = sorted(x.rows[:the.Few*2], key=_fn, reverse=True)
   x.rows = lst[:the.Few] + x.rows[the.Few*2:] + lst[the.Few:] 
   return first

--- a/ezr/ezrtest.py
+++ b/ezr/ezrtest.py
@@ -81,9 +81,9 @@ def eg__tree():
   n    = len(data.rows)//2
   train, holdout= data.rows[:n], data.rows[n:]
   tree = Tree(clone(data, likely(D(train))))
-  treeShow(tree)
-  print(int(best(sorted(holdout, 
-                        key=lambda row: treeLeaf(tree,row).ys.mu)[:the.Check])))
+  treeShow(data, tree)
+  print(int(best(sorted(holdout,
+                        key=lambda row: treeLeaf(tree,row).mu)[:the.Check])))
 
 # def eg_ezr():
 #   data = Data(csv(the.file))
@@ -103,7 +103,7 @@ def funs(*lst):
   def sway1( _, t,T):                   return so(d,T, distFastermap(D(t), sway2=False))
   def sway2( _, t,T):                   return so(d,T, distFastermap(D(t), sway2=True))
   def xploit(_, t,T): the.acq="xploit"; return so(d,T, likely(D(t)))
-  def xplor( _, t,T): the.acq="xplore"; return so(d,T, likely(D(t)))
+  def xplor( _, t,T): the.acq="xplor" ; return so(d,T, likely(D(t)))
   rxs= dict(adapt=adapt, all=all, bore=bore, check=check, rand=rand, 
             kpp=kpp, near=near, sway1=sway1, sway2=sway2,
             xploit=xploit, xplor=xplor)


### PR DESCRIPTION
## Summary
Three high-severity fixes in one PR:

- **"xplore" typo** (`ezrtest.py:106`): experiments labeled "xplor" were silently running "adapt" instead
- **eg__tree crash** (`ezrtest.py:84,86`): wrong `treeShow()` signature (missing `data` arg) and non-existent `.ys` attribute (should be `.mu`)
- **Epsilon guard** (`ezr.py:271`): `abs(b*q - r + 1e-32)` → `(abs(b*q - r) + 1e-32)` to reliably prevent division by zero

## Test plan
- [ ] Run `python3 -B ezrtest.py --tree` — should no longer crash
- [ ] Run `python3 -B ezrtest.py --all` — eg__tree is included and should pass
- [ ] Run `make ~/tmp/dist2.log` — xplor results should now differ from adapt

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)