### PR TITLE
Optimize _cliffs() from O(n*m) to O(n log m) using bisect

### DIFF
--- a/ezr/stats.py
+++ b/ezr/stats.py
@@ -50,8 +50,8 @@ def same(x:list[Qty], y:list[Qty],Ks=0.95,Delta="smed") -> bool:
 
   def _cliffs():
     "How frequently are x items are gt,lt than y items?"
-    gt = sum(a > b for a in x for b in y)
-    lt = sum(a < b for a in x for b in y)
+    gt = sum(bisect.bisect_left(y, a) for a in x)
+    lt = sum(m - bisect.bisect_right(y, a) for a in x)
     return abs(gt - lt) / (n * m)
   
   def _ks():


### PR DESCRIPTION
## Summary
- `_cliffs()` used brute-force nested loops O(n*m) to count gt/lt pairs
- Since x and y are already sorted, uses `bisect.bisect_left/right` for O(log m) per element
- `bisect` was already imported but unused — this was likely the intended optimization
- The `profile()` function in the same file notes: *"most of the time is in _cliffs"*

## Test plan
- [ ] Run `python3 -B stats.py` to profile — should show significant speedup
- [ ] Verify `same()` produces identical results on test data before/after

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)