### PR TITLE
Optimize distFastermap membership test from O(n*m) to O(n) via id-set

### DIFF
--- a/ezr/ezr.py
+++ b/ezr/ezr.py
@@ -202,7 +202,8 @@ def distFastermap(data,rows=None, sway2=True):
     n   = len(rest)//2
     raw = raw[:n] if Y(east) < Y(west) else raw[n:]
     if sway2 and len(raw) < 2:
-      raw = shuffle([r for r in rows if r not in out.rows])
+      seen = set(id(r) for r in out.rows)
+      raw = shuffle([r for r in rows if id(r) not in seen])
   return sorted(out.rows, key=Y)
 
 # ## Likelihood -------------------------------------------------------


### PR DESCRIPTION
## Summary
- `r not in out.rows` was O(m) per row (list linear scan), making the line O(n*m) total
- Now builds a `set(id(r))` for O(1) lookup, reducing to O(n)

## Test plan
- [ ] Run `python3 -B ezrtest.py --fmap` to verify identical results

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)